### PR TITLE
feat: add skus, checkout.session and data reset functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-stateful-mock",
-  "version": "0.0.15",
+  "version": "0.0.16",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/src/api/AccountData.ts
+++ b/src/api/AccountData.ts
@@ -1,4 +1,4 @@
-export class AccountData<T extends {id: string, created: number}> {
+export class AccountData<T extends {id: string, created?: number}> {
 
     private data: {[accountId: string]: {[id: string]: T}} = {};
 

--- a/src/api/AccountData.ts
+++ b/src/api/AccountData.ts
@@ -1,8 +1,12 @@
+export const accountStore: AccountData<any>[] = [];
+
 export class AccountData<T extends {id: string, created?: number}> {
 
     private data: {[accountId: string]: {[id: string]: T}} = {};
 
-    constructor() {}
+    constructor() {
+        accountStore.push(this);
+    }
 
     get(accountId: string, objectId: string): T {
         return (this.data[accountId] && this.data[accountId][objectId]) || null;
@@ -33,6 +37,13 @@ export class AccountData<T extends {id: string, created?: number}> {
 
     remove(accountId: string, objectId: string): void {
         if (this.data[accountId]) {
+            delete this.data[accountId][objectId];
+        }
+    }
+
+    removeAll(accountId: string): void {
+        const records = this.data[accountId];
+        for (const objectId in records) {
             delete this.data[accountId][objectId];
         }
     }

--- a/src/api/checkout.sessions.ts
+++ b/src/api/checkout.sessions.ts
@@ -1,0 +1,99 @@
+import Stripe from "stripe";
+import { AccountData } from "./AccountData";
+import { generateId, stringifyMetadata } from "./utils";
+import { verify } from "./verify";
+import { RestError } from "./RestError";
+import log = require("loglevel");
+
+export namespace checkout {
+  export namespace sessions {
+    const accountCheckoutSessions = new AccountData<Stripe.Checkout.Session>();
+
+    export function create(
+      accountId: string,
+      params: Stripe.Checkout.SessionCreateParams
+    ): Stripe.Checkout.Session {
+      log.debug("checkout.session.create", accountId, params);
+
+      verify.requiredParams(params, ["cancel_url"]);
+      verify.requiredParams(params, ["payment_method_types"]);
+      verify.requiredParams(params, ["success_url"]);
+
+      const sessionId = `cs_${generateId()}`;
+      if (accountCheckoutSessions.contains(accountId, sessionId)) {
+        throw new RestError(400, {
+          code: "resource_already_exists",
+          doc_url:
+            "https://stripe.com/docs/error-codes/resource-already-exists",
+          message: `Checkout session already exists.`,
+          type: "invalid_request_error",
+        });
+      }
+
+      const subtotal = params.line_items?.reduce((acc, item) => {
+        const amount =
+          item.amount ??
+          item.price_data.unit_amount ??
+          Number.parseInt(item.price || "0");
+        return (acc += amount);
+      }, 0);
+
+      const session: Stripe.Checkout.Session = {
+        id: sessionId,
+        object: "checkout.session",
+        amount_subtotal: subtotal,
+        amount_total: subtotal,
+        allow_promotion_codes: params.allow_promotion_codes ?? true,
+        billing_address_collection: params.billing_address_collection ?? null,
+        client_reference_id: params.client_reference_id ?? null,
+        cancel_url: params.cancel_url,
+        customer_email: params.customer_email ?? null,
+        customer: {
+          id: `cu_${generateId()}`,
+          object: "customer",
+          email: params.customer_email ?? null,
+          name: "Some Customer",
+        } as any,
+        currency: "gbp",
+        mode: params.mode ?? "payment",
+        livemode: false,
+        line_items: (params.line_items as any) || [],
+        locale: params.locale ?? "auto",
+        metadata: stringifyMetadata(params.metadata),
+        payment_status: "paid",
+        payment_method_types: params.payment_method_types,
+        payment_intent: null,
+        setup_intent: null,
+        shipping: null,
+        shipping_address_collection: null,
+        subscription: null,
+        submit_type: params.submit_type ?? "pay",
+        success_url: params.success_url,
+        total_details: null,
+      };
+
+      accountCheckoutSessions.put(accountId, session);
+      return session;
+    }
+
+    export function retrieve(
+      accountId: string,
+      checkoutSessionId: string,
+      paramName: string
+    ): Stripe.Checkout.Session {
+      log.debug("checkout.session.retrieve", accountId, checkoutSessionId);
+
+      const session = accountCheckoutSessions.get(accountId, checkoutSessionId);
+      if (!session) {
+        throw new RestError(404, {
+          code: "resource_missing",
+          doc_url: "https://stripe.com/docs/error-codes/resource-missing",
+          message: `No such checkout session: ${checkoutSessionId}`,
+          param: paramName,
+          type: "invalid_request_error",
+        });
+      }
+      return session;
+    }
+  }
+}

--- a/src/api/skus.ts
+++ b/src/api/skus.ts
@@ -1,0 +1,87 @@
+import Stripe from "stripe";
+import {AccountData} from "./AccountData";
+import {applyListOptions, generateId, stringifyMetadata} from "./utils";
+import {verify} from "./verify";
+import {RestError} from "./RestError";
+import log = require("loglevel");
+
+export namespace skus {
+
+    const accountSkus = new AccountData<Stripe.Sku>();
+
+    export function create(accountId: string, params: Stripe.SkuCreateParams): Stripe.Sku {
+        log.debug("products.create", accountId, params);
+
+        verify.requiredParams(params, ["currency"]);
+        verify.requiredParams(params, ["inventory"]);
+        verify.requiredParams(params, ["price"]);
+        verify.requiredParams(params, ["product"]);
+
+        const skuId = params.id || `sku_${generateId()}`;
+        if (accountSkus.contains(accountId, skuId)) {
+            throw new RestError(400, {
+                code: "resource_already_exists",
+                doc_url: "https://stripe.com/docs/error-codes/resource-already-exists",
+                message: `Sku already exists.`,
+                type: "invalid_request_error"
+            });
+        }
+
+        const sku: Stripe.Sku = {
+            id: skuId,
+            object: "sku",
+            active: params.active ?? true,
+            attributes: params.attributes || {},
+            created: (Date.now() / 1000) | 0,
+            currency: params.currency,
+            image: params.image ?? null,
+            inventory: {
+              ...params.inventory,
+              quantity: params.inventory.quantity ?? null,
+              value: params.inventory.value ?? null
+            },
+            livemode: false,
+            metadata: stringifyMetadata(params.metadata),
+            package_dimensions: params.package_dimensions ?? null,
+            price: params.price,
+            product: params.product,
+            updated: (Date.now() / 1000) | 0,
+        };
+
+        accountSkus.put(accountId, sku);
+        return sku;
+    }
+
+    export function retrieve(accountId: string, skuId: string, paramName: string): Stripe.Sku {
+        log.debug("sku.retrieve", accountId, skuId);
+
+        const sku = accountSkus.get(accountId, skuId);
+        if (!sku) {
+            throw new RestError(404, {
+                code: "resource_missing",
+                doc_url: "https://stripe.com/docs/error-codes/resource-missing",
+                message: `No such sku: ${skuId}`,
+                param: paramName,
+                type: "invalid_request_error"
+            });
+        }
+        return sku;
+    }
+
+    export function list(accountId: string, params: Stripe.SkuListParams): Stripe.ApiList<Stripe.Sku> {
+        log.debug("products.list", accountId, params);
+
+        let data = accountSkus.getAll(accountId);
+        if (params.active !== undefined) {
+            data = data.filter(d => d.active === params.active);
+        }
+        if (params.ids) {
+            data = data.filter(d => params.ids.indexOf(d.id) !== -1);
+        }
+        if (params.product !== undefined) {
+            data = data.filter(d => d.product === params.product);
+        }
+        
+        return applyListOptions(data, params, (id, paramName) => retrieve(accountId, id, paramName));
+    }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import {routes} from "./routes";
 import {RestError} from "./api/RestError";
 import {idempotencyRoute} from "./api/idempotency";
 import {auth} from "./api/auth";
+import {accountStore} from './api/AccountData';
 import log = require("loglevel");
 
 export function createExpressApp(): express.Application {
@@ -29,4 +30,10 @@ export function createExpressApp(): express.Application {
     });
 
     return app;
+}
+
+export function resetData(accountId: string = "acct_default"): void {
+  for(const accountData of accountStore) {
+    accountData.removeAll(accountId)
+  }
 }

--- a/src/routes.ts
+++ b/src/routes.ts
@@ -11,6 +11,8 @@ import {refunds} from "./api/refunds";
 import {subscriptions} from "./api/subscriptions";
 import {taxRates} from "./api/taxRates";
 import {expandList, expandObject} from "./api/utils";
+import {skus} from "./api/skus";
+import {checkout} from "./api/checkout.sessions";
 
 const routes = express.Router();
 
@@ -75,6 +77,16 @@ routes.post("/v1/charges/:id/capture", (req, res) => {
 routes.get("/v1/charges/:id/refunds", (req, res) => {
     const refundList = refunds.list(getRequestAccountId(req), {...req.query, charge: req.params.id});
     return res.status(200).json(refundList);
+});
+
+routes.get("/v1/checkout/sessions/:id", (req, res) => {
+    const session = checkout.sessions.retrieve(getRequestAccountId(req), req.params.id, "id");
+    return res.status(200).json(session);
+});
+
+routes.post("/v1/checkout/sessions", (req, res) => {
+    const session = checkout.sessions.create(getRequestAccountId(req), req.body);
+    return res.status(200).json(session);
 });
 
 routes.post("/v1/customers", (req, res) => {
@@ -222,6 +234,21 @@ routes.get("/v1/refunds", (req, res) => {
 routes.get("/v1/refunds/:id", (req, res) => {
     const refund = refunds.retrieve(getRequestAccountId(req), req.params.id, "id");
     return res.status(200).json(refund);
+});
+
+routes.post("/v1/skus", (req, res) => {
+    const sku = skus.create(getRequestAccountId(req), req.body);
+    return res.status(200).json(sku);
+});
+
+routes.get("/v1/skus", (req, res) => {
+    const skuList = skus.list(getRequestAccountId(req), req.query);
+    return res.status(200).json(skuList);
+});
+
+routes.get("/v1/skus/:id", (req, res) => {
+    const sku = skus.retrieve(getRequestAccountId(req), req.params.id, "id");
+    return res.status(200).json(sku);
 });
 
 routes.post("/v1/subscriptions", (req, res) => {


### PR DESCRIPTION
Pending tests, once I figure out how it's done.

Adds these endpoints
- skus.create
- skus.retrieve
- skus.list
- checkout.session.create
- checkout.session.retrieve

Adds a `resetData` export to support `beforeEach` / `afterEach` pattern.